### PR TITLE
DAO: Explicitly implicit parameter list for manifest to context bound

### DIFF
--- a/src/main/scala/com/stratio/common/utils/components/dao/DAOComponent.scala
+++ b/src/main/scala/com/stratio/common/utils/components/dao/DAOComponent.scala
@@ -51,8 +51,8 @@ trait DAOComponent[K, V, M] {
 
     def entity: String
 
-    def fromVtoM(v: V)(implicit manifest: Manifest[M]): M
+    def fromVtoM[TM >: M <: M : Manifest](v: V): TM
 
-    def fromMtoV(m: M)(implicit manifest: Manifest[M]): V
+    def fromMtoV[TM <: M : Manifest](m: TM): V
   }
 }

--- a/src/main/scala/com/stratio/common/utils/components/dao/GenericDAOComponent.scala
+++ b/src/main/scala/com/stratio/common/utils/components/dao/GenericDAOComponent.scala
@@ -36,7 +36,7 @@ with ZookeeperRepositoryComponent with TypesafeConfigComponent with SparkLoggerC
       else key.get
     }
 
-    override def fromVtoM(v: Array[Byte])(implicit manifest: Manifest[M]): M = read[M](new String(v))
-    override def fromMtoV(m: M)(implicit manifest: Manifest[M]): Array[Byte] = write(m).getBytes
+    override def fromVtoM[TM <: M : Manifest](v: Array[Byte]): TM = read[TM](new String(v))
+    override def fromMtoV[TM <: M : Manifest](m: TM): Array[Byte] = write(m).getBytes
   }
 }

--- a/src/test/scala/com/stratio/common/utils/components/dao/DaoComponentTest.scala
+++ b/src/test/scala/com/stratio/common/utils/components/dao/DaoComponentTest.scala
@@ -113,9 +113,9 @@ trait DummyDAOComponent extends DAOComponent[String, String, DummyModel] with Du
       else key.get
     }
 
-    override def fromVtoM(v: String)(implicit manifest: Manifest[DummyModel]): DummyModel = new DummyModel(v)
+    override def fromVtoM[TM >: DummyModel <: DummyModel : Manifest](v: String): TM = new DummyModel(v)
 
-    override def fromMtoV(m: DummyModel)(implicit manifest: Manifest[DummyModel]): String = m.property
+    override def fromMtoV[TM <: DummyModel : Manifest](m: TM): String = m.property
   }
 }
 


### PR DESCRIPTION
Changed explicitly declared implicit manifest parameter list to `Manifest` context bound.