### PR TITLE
Added time metrics support component

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ Config
   
   Public interface and functions for use Typesafe configuration library as a Config Component
   
+Metrics - time
+==============
+
+It allows measuring the time that took executing certain block code.
+You can instantiate it by extending an implementation of ```TimeComponent```:
+
+```scala
+object MyModule extends SystemClockTimeComponent
+```
+
+You can measure the time and get the result of evaluating some ```T``` expression:
+
+```scala
+import MyModule._
+val (result, timeItTook) = time(2 + 2)
+```
+
+Or just evaluate the time, ignoring the result:
+
+```scala
+import MyModule._
+val duration = justTime {
+  println(2 + 2)
+}
+```
 
 Functional utilities
 ====================

--- a/src/main/scala/com/stratio/common/utils/components/metrics/TimeComponent.scala
+++ b/src/main/scala/com/stratio/common/utils/components/metrics/TimeComponent.scala
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.components.metrics
+
+import scala.concurrent.duration.Duration
+
+trait TimeComponent {
+
+  type Milliseconds = Long
+
+  /**
+   * Executes given [[T]] expression and grabs
+   * the time that took evaluating it.
+   * @param t Lazy [[T]] expression.
+   * @tparam T Expression type
+   * @return A tuple with both the result of
+   *         evaluating expression 't' and the
+   *         duration it took.
+   */
+  def time[T](t: => T): (T,Duration) = {
+    import scala.concurrent.duration._
+    val startTime = now()
+    val result = t
+    (result,(now() - startTime).millis)
+  }
+
+  /**
+   * Just takes the time that takes evaluating
+   * some Unit expression.
+   * @param expression Lazy Unit expression to be
+   *                   evaluated
+   * @return Just the time it took to be evaluated.
+   */
+  def justTime(expression: => Unit): Duration = {
+    val (_, timeItTook) = time(expression)
+    timeItTook
+  }
+
+  def now(): Milliseconds
+
+}

--- a/src/main/scala/com/stratio/common/utils/components/metrics/impl/SystemClockTimeComponent.scala
+++ b/src/main/scala/com/stratio/common/utils/components/metrics/impl/SystemClockTimeComponent.scala
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.components.metrics.impl
+
+import com.stratio.common.utils.components.metrics.TimeComponent
+
+/**
+ * Time component based on JVM system's clock.
+ */
+trait SystemClockTimeComponent extends TimeComponent {
+
+  def now(): Milliseconds =
+    System.currentTimeMillis()
+
+}

--- a/src/test/scala/com/stratio/common/utils/components/metrics/DummyTimeComponent.scala
+++ b/src/test/scala/com/stratio/common/utils/components/metrics/DummyTimeComponent.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.components.metrics
+
+/**
+ * Dummy component that each time returns the
+ * double of last millisecond number.
+ * It starts from zero.
+ */
+trait DummyTimeComponent extends TimeComponent {
+
+  private var current: Int = 0
+  private val times: Stream[Long] = 1L #:: times.map(_ * 2)
+
+  def now(): Milliseconds = synchronized{
+    val t = times(current)
+    current += 1
+    t
+  }
+
+  def reset(): Unit = synchronized(current=0)
+
+}

--- a/src/test/scala/com/stratio/common/utils/components/metrics/TimeComponentTest.scala
+++ b/src/test/scala/com/stratio/common/utils/components/metrics/TimeComponentTest.scala
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.components.metrics
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class TimeComponentTest extends FlatSpec with Matchers {
+
+  behavior of "TimeComponent"
+
+  object Timer extends DummyTimeComponent
+
+  import scala.concurrent.duration._
+  import Timer._
+
+  it should "measure time that takes evaluating some expression" in {
+    val (result,t) = time { 2 + 2}
+    result shouldEqual 4
+    t shouldEqual 1.millis
+  }
+
+  it should "measure time ignoring the result of some expression" in {
+    val t = justTime {
+      "hi"
+    }
+    t shouldEqual 4.millis
+  }
+
+}


### PR DESCRIPTION
This feature provides a way of measuring the time that took executing certain block code.
You can instantiate it by extending an implementation of ```TimeComponent```:

```scala
object MyModule extends SystemClockTimeComponent
```

You can measure the time and get the result of evaluating some ```T``` expression:

```scala
import MyModule._
val (result, timeItTook) = time(2 + 2)
```

Or just evaluate the time, ignoring the result:

```scala
import MyModule._
val duration = justTime {
  println(2 + 2)
}
```

In both cases, time is expressed as a ```scala.concurrent.duration.Duration```