### PR TITLE
Functional package: anonymous iterators instantiation with syntax sugar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Now is possible to create some generic modules:
 - Logger
 - Configuration
 
+Appart from these modules, a functional package has been added in order to provide some extended functionality
+regarding scala collections and functional utilities.
 
 Repositories
 ============
@@ -37,4 +39,60 @@ Config
   
   Public interface and functions for use Typesafe configuration library as a Config Component
   
-  
+
+Functional utilities
+====================
+
+Anonymous iterators
+-------------------
+
+These functional package iterator functions allow defining anonymous iterators with higher kinded functions.
+
+A ```StatefulIterator``` keeps track of its internal state, and allows defining the way to retrieve a new element
+from the iterator based on the internal state:
+
+```scala
+import com.stratio.common.utils.functional._
+val ite: StatefulIterator[String,Int] =
+  iterator(
+    0,
+    _ < 10,
+    state => (state + 1, Random.nextString(state)))
+ ```
+
+Have in mind that the signature implies defining:
+* the initial internal state
+* the ```hasNext``` function regarding the internal current state
+* the ```next``` function that, besides returning an element, mutates the iterator internal state.
+
+You can also create a stateful iterator with the initial state and a ```next``` function that optionally might make
+the iterator stop:
+
+```scala
+import com.stratio.common.utils.functional._
+val ite: StatefulIterator[String,Int] =
+  iterator(
+    0,
+    state => Option((state + 1, Random.nextString(state)).find(_ => state < 10))
+```
+
+A ```StatelessIterator```  allows defining the way to retrieve a new element from the iterator. It's actually an
+```Iterator[Option[T]]``` with some apply helpers. As well as ```StatefulIterator``` worked, you can define both
+```hasNext``` and ```next``` functions:
+
+```scala
+import com.stratio.common.utils.functional._
+val ite: StatelessIterator[String] =
+  iterator(
+    database.hasResults(),
+    database.read())
+```
+...or just define a single function that optionally might make the iterator stop:
+
+```scala
+import com.stratio.common.utils.functional._
+val ite: StatelessIterator[String] =
+  iterator(
+    if (database.hasResults()) Option(database.read())
+    else None)
+```

--- a/src/main/scala/com/stratio/common/utils/functional/Dsl.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/Dsl.scala
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.functional
+
+/**
+ * Provides a higher layer of abstraction for using
+ * extended functionality at 'functional' package.
+ */
+trait Dsl {
+
+  def iterator[T,S](
+    initialState: S,
+    hasNextFunc: S => Boolean,
+    nextFunc: S => (S,T)): StatefulIterator[T,S] =
+    StatefulIterator.apply[T,S](initialState,hasNextFunc,nextFunc)
+
+  def iterator[T,S](
+    initialState: S,
+    nextFunc: S => Option[(S,T)]): StatefulIterator[T,S] =
+    StatefulIterator.apply[T,S](initialState,nextFunc)
+
+  def iterator[T](
+    hasNextFunc: => Boolean,
+    nextFunc: => T): StatelessIterator[T] =
+    StatelessIterator[T](hasNextFunc)(nextFunc)
+
+  def iterator[T](
+    nextFunc: => Option[T]): StatelessIterator[T] =
+    StatelessIterator[T](nextFunc)
+
+}

--- a/src/main/scala/com/stratio/common/utils/functional/StatefulIterator.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/StatefulIterator.scala
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.functional
+
+/**
+ * An [[StatefulIterator]] is just an [[Iterator]] that
+ * needs to track some kind of state for determining if
+ * it has next values or not.
+ */
+trait StatefulIterator[T,S] extends Iterator[Option[T]] {
+
+  /**
+   * Internal iterator state.
+   */
+  def state: S
+
+}
+
+object StatefulIterator {
+
+  /**
+   * It creates a new [[StatefulIterator]] of [[T]]s
+   * @param initialState Initial internal state of the iterator.
+   * @param nextFunc Lambda that represents the state transition and
+   *                 retrieval of the next element in iterator.
+   * @tparam T Contained element type.
+   * @tparam S State type
+   * @return An stateful iterator.
+   */
+  def apply[T,S](
+    initialState: S,
+    hasNextFunc: S => Boolean,
+    nextFunc: S => (S,T)): StatefulIterator[T,S] = {
+
+    new StatefulIterator[T,S] { self =>
+
+      /**
+       * It's necessary to synchronize '_state'
+       * to make the iterator thread-safe.
+       */
+      private var _state: S = initialState
+
+      def state: S = self.synchronized(_state)
+
+      override def hasNext: Boolean =
+        self.synchronized(hasNextFunc(_state))
+
+      override def next(): Option[T] = self.synchronized{
+        if (hasNext) {
+          val (newState,t) = nextFunc(_state)
+          _state = newState
+          Option(t)
+        }
+        else None
+      }
+
+    }
+
+  }
+
+  /**
+   * It creates a new [[StatefulIterator]] of [[T]]s
+   * @param initialState Initial internal state of the iterator.
+   * @param nextFunc Lambda that represents the state transition and
+   *                 retrieval of the next element in iterator (if possible).
+   * @tparam T Contained element type.
+   * @tparam S State type
+   * @return An stateful iterator.
+   */
+  def apply[T,S](
+    initialState: S,
+    nextFunc: S => Option[(S,T)]): StatefulIterator[T,S] = {
+
+    new StatefulIterator[T,S] { self =>
+
+      private var _state: S = initialState
+
+      def state: S = self.synchronized(_state)
+
+      private var last: Option[(S,T)] = nextFunc(initialState)
+
+      override def next(): Option[T] = self.synchronized{
+        val result = last.map{
+          case (newState,t) =>
+            _state = newState
+            t
+        }
+        last = nextFunc(_state)
+        result
+      }
+
+      override def hasNext: Boolean = self.synchronized(last.isDefined)
+
+    }
+
+  }
+
+}

--- a/src/main/scala/com/stratio/common/utils/functional/StatelessIterator.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/StatelessIterator.scala
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.functional
+
+/**
+ * An [[StatelessIterator]] is just an [[Iterator]] that
+ * has no need to track its state for determining if
+ * it has next values or not.
+ */
+trait StatelessIterator[T] extends Iterator[Option[T]]
+
+object StatelessIterator {
+
+  /**
+   * It creates a new [[StatelessIterator]] of [[T]]s
+   * @param nextFunc Lambda that represents the
+   *                 retrieval of the next element in iterator.
+   * @tparam T Contained element type.
+   * @return A stateless iterator.
+   */
+  def apply[T](
+    hasNextFunc: => Boolean)(
+    nextFunc: => T): StatelessIterator[T] = {
+
+    new StatelessIterator[T] {
+
+      override def hasNext: Boolean =
+        hasNextFunc
+
+      override def next(): Option[T] =
+        if (hasNext) Option(nextFunc)
+        else None
+
+    }
+
+  }
+
+  /**
+   * It creates a new [[StatelessIterator]] of [[T]]s
+   * @param nextFunc Lambda that represents the
+   *                 retrieval of the next element in iterator.
+   *                 Returning a None represents the end of the
+   *                 Iterator.
+   * @tparam T Contained element type.
+   * @return A stateless iterator.
+   */
+  def apply[T](nextFunc: => Option[T]): StatelessIterator[T] = {
+
+    new StatelessIterator[T] { self =>
+
+      private var last: Option[T] = nextFunc
+
+      override def next(): Option[T] = self.synchronized{
+        val result = last
+        last = nextFunc
+        result
+      }
+
+      override def hasNext: Boolean = self.synchronized(last.isDefined)
+
+    }
+
+  }
+
+}

--- a/src/main/scala/com/stratio/common/utils/functional/package.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/package.scala
@@ -1,0 +1,19 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils
+
+package object functional extends Dsl

--- a/src/test/scala/com/stratio/common/utils/functional/StatefulIteratorTest.scala
+++ b/src/test/scala/com/stratio/common/utils/functional/StatefulIteratorTest.scala
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.functional
+
+import scala.util.Random
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class StatefulIteratorTest extends FlatSpec
+  with Matchers
+  with StatefulIteratorTestInitialization {
+
+  behavior of "StatefulIterator"
+
+  /*
+   * Define a new StatefulIterator of Strings (where the state is an int).
+   * The initial state is zero and the 'hasNext' condition is the state
+   * having having a value lower than 10. The 'next' state-mutating function
+   * is defined as incrementing by one the state and returning an external
+   * seq value at the current index.
+   */
+  def myIterator1(): StatefulIterator[String,Int] =
+    iterator(
+      0,
+      _ < 10,
+      state => (
+        state + 1,
+        strings.zipWithIndex.find{ case (s,idx) => idx == state }.map(_._1).get))
+
+  def myIterator2(): StatefulIterator[String,Int] =
+    iterator(0, state =>
+      strings.zipWithIndex.find{ case (s,idx) => idx == state && state < 10}.map{
+        case (s,_) => (state + 1, s)
+      })
+
+  it should "allow defining a new stateful iterator of Option[T]" in {
+
+
+    val ite1: StatefulIterator[String,Int] = myIterator1()
+
+    val ite2: StatefulIterator[String,Int] = myIterator2()
+
+  }
+
+  it should "allow assigning the StatefulIterator[T,S] into a Iterator[Option[T]]" in {
+
+    val ite1: StatefulIterator[String,Int] = myIterator1()
+
+    val ite2: StatefulIterator[String,Int] = myIterator2()
+
+    /*
+     * The StatefulIterator is actually an Iterator[Option[T]]
+     */
+    val ite3: Iterator[Option[String]] = ite1
+    val ite4: Iterator[Option[String]] = ite2
+
+  }
+
+  it should "mutate internal state of the iterator when iterating over it" in {
+
+    val ite1: StatefulIterator[String,Int] = myIterator1()
+
+    val ite2: StatefulIterator[String,Int] = myIterator2()
+
+    def checkIterator(ite: StatefulIterator[String,Int]): Unit = {
+      val chains: IndexedSeq[Any] = (1 to 2).map { _ =>
+        if (ite.hasNext) ite.next()
+      }
+      ite.state shouldEqual 2
+      chains.head shouldEqual Option(strings.head)
+      chains(1) shouldEqual Option(strings(1))
+      chains.isDefinedAt(2) shouldEqual false
+    }
+
+    checkIterator(ite1)
+    checkIterator(ite2)
+
+  }
+
+  it should "iterate until state doesn't allows it" in {
+
+    val stopCondition = 10
+
+    val ite1: StatefulIterator[String,Int] = myIterator1()
+
+    val ite2: StatefulIterator[String,Int] = myIterator2()
+
+    def checkIterator(ite: StatefulIterator[String,Int]): Unit = {
+      ite.toList shouldEqual strings.take(stopCondition).map(Option.apply).toList
+      ite.hasNext shouldEqual false
+      ite.next() shouldEqual None
+    }
+
+    checkIterator(ite1)
+    checkIterator(ite2)
+
+  }
+
+}
+
+trait StatefulIteratorTestInitialization {
+
+  val stringLength = 5
+
+  val strings: IndexedSeq[String] =
+    (1 to 20).map(_ => Random.nextString(stringLength))
+
+}

--- a/src/test/scala/com/stratio/common/utils/functional/StatelessIteratorTest.scala
+++ b/src/test/scala/com/stratio/common/utils/functional/StatelessIteratorTest.scala
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.functional
+
+import scala.util.Random
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class StatelessIteratorTest extends FlatSpec
+  with Matchers
+  with StatelessIteratorTestInitialization {
+
+  behavior of "StatelessIterator"
+
+  def myIterator1(): WithDataBaseAndExternalState =
+    new WithDataBaseAndExternalState {
+      /*
+       * Define a new StatelessIterator of Strings.
+       * HasNext function is provided by some external state.
+       * The 'next' function is defined as invoking an external
+       * 'database' method.
+       */
+      val ite: StatelessIterator[String] = iterator(state < 10,{
+        state += 1
+        database.read()
+      })
+    }
+
+  def myIterator2(): WithDataBaseAndExternalState =
+    new WithDataBaseAndExternalState {
+      val ite: StatelessIterator[String] = iterator {
+        val oldState = state
+        state += 1
+        Option(database.read()).find(_ => oldState < 10)
+      }
+    }
+
+  it should "allow defining a new stateless iterator of Option[T]" in {
+
+    val ite1 = myIterator1()
+
+    val ite2 = myIterator2()
+
+  }
+
+  it should "allow assigning the StatelessIterator[T] into a Iterator[Option[T]]" in {
+
+    val ite1 = myIterator1()
+
+    val ite2 = myIterator2()
+
+    val ite3: Iterator[Option[String]] = ite1.ite
+
+    val ite4: Iterator[Option[String]] = ite2.ite
+  }
+
+  it should "iterate until external call-by-name expression doesn't allows it" in {
+
+    def checkIterator(
+      obj: WithDataBaseAndExternalState): Unit = {
+      obj.ite.toList.size shouldEqual 10
+    }
+
+    checkIterator(myIterator1())
+
+    checkIterator(myIterator2())
+
+  }
+
+  it should "iterating over an ended iterator should return None elements" in {
+
+    def checkIterator(
+      obj: WithDataBaseAndExternalState): Unit = {
+      val collected = obj.ite.toList
+      collected.size shouldBe 10
+      collected.distinct.size shouldBe 10
+      obj.ite.toList.size shouldBe 0
+      obj.ite.hasNext shouldEqual false
+      obj.ite.next() shouldEqual None
+    }
+
+    checkIterator(myIterator1())
+
+    checkIterator(myIterator2())
+
+  }
+
+}
+
+trait StatelessIteratorTestInitialization {
+
+  /**
+    * Dummy database.
+   */
+  class Database {
+    private val length = 5
+    def read(): String = Random.nextString(length)
+  }
+
+  /**
+   * Some dummy object that owes some state
+   * and has an instance of a dummy database.
+   */
+  abstract class WithDataBaseAndExternalState {
+    var state = 0
+    val database = new Database
+    val ite: StatelessIterator[String]
+  }
+
+}


### PR DESCRIPTION
A functional package has been added in order to provide some extended functionality
regarding scala collections and functional utilities. At this commit, iterator functions have been added.

These functional package iterator functions allow defining anonymous iterators with higher kinded functions.

A ```StatefulIterator``` keeps track of its internal state, and allows defining the way to retrieve a new element
from the iterator based on the internal state:

```scala
import com.stratio.common.utils.functional._
val ite: StatefulIterator[String,Int] =
  iterator(
    0,
    _ < 10,
    state => (state + 1, Random.nextString(state)))
 ```

Have in mind that the signature implies defining:
* the initial internal state
* the ```hasNext``` function regarding the internal current state
* the ```next``` function that, besides returning an element, mutates the iterator internal state.

You can also create a stateful iterator with the initial state and a ```next``` function that optionally might make
the iterator stop:

```scala
import com.stratio.common.utils.functional._
val ite: StatefulIterator[String,Int] =
  iterator(
    0,
    state => Option((state + 1, Random.nextString(state)).find(_ => state < 10))
```

A ```StatelessIterator```  allows defining the way to retrieve a new element from the iterator. It's actually an
```Iterator[Option[T]]``` with some apply helpers. As well as ```StatefulIterator``` worked, you can define both
```hasNext``` and ```next``` functions:

```scala
import com.stratio.common.utils.functional._
val ite: StatelessIterator[String] =
  iterator(
    database.hasResults(),
    database.read())
```
...or just define a single function that optionally might make the iterator stop:

```scala
import com.stratio.common.utils.functional._
val ite: StatelessIterator[String] =
  iterator(
    if (database.hasResults()) Option(database.read())
    else None)
```
