### PR TITLE
Enable Scala cross version builds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.5.0 (Upcoming)
 
+- Enabled Scala cross builds for Scala 2.10 and Scala 2.11.
+
 ## 0.4.2 (Febrary 2016)
 
 - Getnodes added in Zookeeper repository.

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <groupId>com.stratio.common</groupId>
-    <artifactId>common-utils</artifactId>
+    <artifactId>common-utils_2.10</artifactId>
     <version>0.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
@@ -38,8 +38,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.binary.version>2.10</scala.binary.version>
-        <scala.version>2.10.4</scala.version>
         <typesafe.version>1.2.1</typesafe.version>
         <scalatest.version>2.2.2</scalatest.version>
         <junit.version>4.11</junit.version>
@@ -48,6 +46,13 @@
         <curator.version>2.9.0</curator.version>
         <spark.version>1.5.2</spark.version>
         <slf4j.version>1.7.7</slf4j.version>
+        <!-- Scala version and cross build properties -->
+        <scala.binary.version>2.10</scala.binary.version>
+        <scala.version>2.10.4</scala.version>
+        <scala_2.10.version>2.10.4</scala_2.10.version>
+        <scala_2.11.version>2.11.7</scala_2.11.version>
+        <default.scala.binary.version>2.10</default.scala.binary.version>
+        <default.scala.version>${scala_2.10.version}</default.scala.version>
     </properties>
 
     <dependencies>
@@ -115,6 +120,9 @@
     <build>
         <sourceDirectory>src/main/scala</sourceDirectory>
         <testSourceDirectory>src/test/scala</testSourceDirectory>
+        <directory>${project.basedir}/target/${scala.binary.version}</directory>
+        <outputDirectory>${project.build.directory}/classes</outputDirectory>
+        <testOutputDirectory>${project.build.directory}/test-classes</testOutputDirectory>
 
         <plugins>
           <plugin>
@@ -145,7 +153,32 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.stratio.mojo</groupId>
+                <artifactId>scala-cross-build-maven-plugin</artifactId>
+                <version>0.1.0-RC3</version>
+                <configuration>
+                    <defaultScalaBinaryVersion>${default.scala.binary.version}</defaultScalaBinaryVersion>
+                    <defaultScalaVersion>${default.scala.version}</defaultScalaVersion>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>scala-2.10</id>
+            <properties>
+                <scala.binary.version>2.10</scala.binary.version>
+                <scala.version>${scala_2.10.version}</scala.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala-2.11</id>
+            <properties>
+                <scala.binary.version>2.11</scala.binary.version>
+                <scala.version>${scala_2.11.version}</scala.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
- Default Scala binary version is 2.10.
- Profiles scala-2.10 and scala-2.11 allow to switch binary version.
- Appended _2.10 to all artifactId by default.
- Added scala-cross-build-maven-plugin to help with Scala cross builds.