### PR TITLE
Added runtime-based reflect support functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.5.0 (Upcoming)
 
 - Enabled Scala cross builds for Scala 2.10 and Scala 2.11.
+- Added functional extensions library with State(full|less) iterators and reflect type support.
 
 ## 0.4.2 (Febrary 2016)
 

--- a/README.md
+++ b/README.md
@@ -121,3 +121,31 @@ val ite: StatelessIterator[String] =
     if (database.hasResults()) Option(database.read())
     else None)
 ```
+
+Reflect type utilities
+----------------------
+
+It provides a fancy DSL (so an easy way) to determine type equality in Scala.
+
+I.e.:
+
+```scala
+import scala.reflect.classTag
+import com.stratio.common.utils.functional._
+
+class Kid
+class Daddy extends Kid
+class Grandpa extends Daddy
+
+classTag[Kid].isA[Kid] //true
+classTag[Kid].isA[Daddy] //false
+classTag[Daddy].isA[Grandpa] //false
+classTag[Grandpa].isA[Kid] //true
+
+classTag[Kid].isExactlyA[Kid] //true
+classTag[Kid].isExactlyA[Daddy] //false
+classTag[Daddy].isExactlyA[Grandpa] //false
+classTag[Grandpa].isExactlyA[Grandpa] //true
+```
+
+It also works providing the ```Class``` with ```classOf[Kid]``` instead of the ```ClassTag```.

--- a/src/main/scala/com/stratio/common/utils/functional/Dsl.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/Dsl.scala
@@ -16,6 +16,10 @@
 
 package com.stratio.common.utils.functional
 
+import scala.reflect.ClassTag
+
+import com.stratio.common.utils.functional.reflect.ClassTagHelper
+
 /**
  * Provides a higher layer of abstraction for using
  * extended functionality at 'functional' package.
@@ -41,5 +45,9 @@ trait Dsl {
   def iterator[T](
     nextFunc: => Option[T]): StatelessIterator[T] =
     StatelessIterator[T](nextFunc)
+
+  implicit class classTagHelper[T:ClassTag](ct: ClassTag[T]) extends ClassTagHelper(ct)
+
+  implicit class classHelper[T](_class: Class[T]) extends ClassTagHelper(ClassTag[T](_class))
 
 }

--- a/src/main/scala/com/stratio/common/utils/functional/reflect/ClassTagHelper.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/reflect/ClassTagHelper.scala
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.functional.reflect
+
+import scala.reflect.ClassTag
+
+/**
+ * It provides full support for operating with [[ClassTag]] type
+ * runtime-based operations, like:
+ *
+ * {{{
+ *    class Kid
+ *    class Daddy extends Kid
+ *    class Grandpa extends Daddy
+ *
+ *    classTag[Kid].isA[Kid] should equal(true)
+ *    classTag[Kid].isA[Daddy] should equal(false)
+ *    classTag[Daddy].isA[Grandpa] should equal(false)
+ *    classTag[Grandpa].isA[Kid] should equal(true)
+ *
+ * }}}
+ */
+private[functional] class ClassTagHelper[T](ctag: ClassTag[T]){
+
+  /**
+   * Determine (in runtime) whether [[T]] is a subtype of [[U]]
+   */
+  def isA[U](implicit ev: <:<[T,U] = None.orNull): Boolean =
+    Option(ev).isDefined
+
+  /**
+   * Determine (in runtime) whether [[T]] is exactly [[U]]
+   */
+  def isExactlyA[U](implicit ev: =:=[T,U] = None.orNull): Boolean =
+    Option(ev).isDefined
+
+}

--- a/src/test/scala/com/stratio/common/utils/functional/reflect/ClassTagHelperTest.scala
+++ b/src/test/scala/com/stratio/common/utils/functional/reflect/ClassTagHelperTest.scala
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.functional.reflect
+
+import org.scalatest.{Matchers, FlatSpec}
+
+import scala.reflect.classTag
+
+import com.stratio.common.utils.functional._
+
+class ClassTagHelperTest extends FlatSpec
+  with Matchers{
+
+  behavior of "ClassTagHelper"
+
+  class Kid
+  class Daddy extends Kid
+  class Grandpa extends Daddy
+
+  it should "determine if a type inherits from some other" in {
+    classTag[Kid].isA[Kid] should equal(true)
+    classTag[Kid].isA[Daddy] should equal(false)
+    classTag[Daddy].isA[Grandpa] should equal(false)
+    classTag[Grandpa].isA[Kid] should equal(true)
+  }
+
+  it should "determine if a type inherits from some other (using class format)" in {
+    classOf[Kid].isA[Kid] should equal(true)
+    classOf[Kid].isA[Daddy] should equal(false)
+    classOf[Daddy].isA[Grandpa] should equal(false)
+    classOf[Grandpa].isA[Kid] should equal(true)
+  }
+
+  it should "determine if a type is exactly some other" in {
+    classTag[Kid].isExactlyA[Kid] should equal(true)
+    classTag[Kid].isExactlyA[Daddy] should equal(false)
+    classTag[Daddy].isExactlyA[Grandpa] should equal(false)
+    classTag[Grandpa].isExactlyA[Grandpa] should equal(true)
+  }
+
+  it should "determine if a type isExactly some other (using class format)" in {
+    classOf[Kid].isExactlyA[Kid] should equal(true)
+    classOf[Kid].isExactlyA[Daddy] should equal(false)
+    classOf[Daddy].isExactlyA[Grandpa] should equal(false)
+    classOf[Grandpa].isExactlyA[Grandpa] should equal(true)
+  }
+
+}


### PR DESCRIPTION
Reflect type utilities
----------------------

It provides a fancy DSL (so an easy way) to determine type equality in Scala.

I.e.:

```scala
import scala.reflect.classTag
import com.stratio.common.utils.functional._

class Kid
class Daddy extends Kid
class Grandpa extends Daddy

classTag[Kid].isA[Kid] //true
classTag[Kid].isA[Daddy] //false
classTag[Daddy].isA[Grandpa] //false
classTag[Grandpa].isA[Kid] //true

classTag[Kid].isExactlyA[Kid] //true
classTag[Kid].isExactlyA[Daddy] //false
classTag[Daddy].isExactlyA[Grandpa] //false
classTag[Grandpa].isExactlyA[Grandpa] //true
```

It also works providing the ```Class``` with ```classOf[Kid]``` instead of the ```ClassTag```.