### PR TITLE
Added support for executing Future.option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.6.0 (Upcoming)
 
+- Added compatibility for invoking Future.sequence for Options in Scala [(SI-9694)](https://issues.scala-lang
+.org/browse/SI-9694)
+
 ## 0.5.0 (March 2016)
 
 - Enabled Scala cross builds for Scala 2.10 and Scala 2.11.

--- a/README.md
+++ b/README.md
@@ -149,3 +149,19 @@ classTag[Grandpa].isExactlyA[Grandpa] //true
 ```
 
 It also works providing the ```Class``` with ```classOf[Kid]``` instead of the ```ClassTag```.
+
+Concurrent utilities
+====================
+
+Future.option
+-------------
+
+Despite of not having a way a to invoke ```Future.sequence``` with an ```Option``` , the concurrent utilities provide
+  a nice ```Option[Future[T]] => Future[Option[T]]``` function with the ```Future.option``` method:
+
+```scala
+import com.stratio.common.utils.concurrent._
+
+val someFuture = Option(Future(1))
+val result: Future[Option[Int]] = Future.option(someFuture)
+```

--- a/src/main/scala/com/stratio/common/utils/concurrent/Dsl.scala
+++ b/src/main/scala/com/stratio/common/utils/concurrent/Dsl.scala
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils.concurrent
+
+import scala.language.higherKinds
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * Provides a higher layer of abstraction for using
+ * extended functionality at 'concurrent' package.
+ */
+trait Dsl {
+
+  implicit class FutureCompanion(companion: Future.type) extends FutureFunctions(companion)
+
+}

--- a/src/main/scala/com/stratio/common/utils/concurrent/FutureFunctions.scala
+++ b/src/main/scala/com/stratio/common/utils/concurrent/FutureFunctions.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils.concurrent
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * Add extra functionality for [[Future]] static functions
+ * @param companion Future companion object
+ */
+class FutureFunctions(companion: Future.type) {
+
+  /**
+   * Simple version of Future.traverse. Transforms a Option[Future[A]] into a Future[Option[A]].
+   * Useful for reducing optional Futures into a single Future.
+   */
+  def option[A]
+    (in: Option[Future[A]])
+    (implicit executor: ExecutionContext): Future[Option[A]] = {
+    Future.sequence(in.toList).map(_.headOption)
+  }
+
+}

--- a/src/main/scala/com/stratio/common/utils/concurrent/package.scala
+++ b/src/main/scala/com/stratio/common/utils/concurrent/package.scala
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils
+
+package object concurrent extends Dsl

--- a/src/test/scala/com/stratio/common/utils/concurrent/FutureCompanionTest.scala
+++ b/src/test/scala/com/stratio/common/utils/concurrent/FutureCompanionTest.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils.concurrent
+
+import scala.concurrent.Future
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Matchers, FlatSpec}
+
+class FutureCompanionTest extends FlatSpec with Matchers with ScalaFutures{
+
+  behavior of "FutureCompanion"
+
+  it should "allow converting an optional future into a future optional value" in {
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val value = Option(Future(1))
+
+    val f: Future[Option[Int]] = Future.option(value)
+
+    whenReady(f){
+      _ shouldEqual Option(1)
+    }
+
+  }
+
+}


### PR DESCRIPTION
Future.option
-------------

Despite of not having a way a to invoke ```Future.sequence``` with an ```Option``` , the concurrent utilities provide
  a nice ```Option[Future[T]] => Future[Option[T]]``` function with the ```Future.option``` method:

```scala
import com.stratio.common.utils.concurrent._

val someFuture = Option(Future(1))
val result: Future[Option[Int]] = Future.option(someFuture)