### PR TITLE
Added monad transformer OptionT and ListT

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,86 @@ classTag[Grandpa].isExactlyA[Grandpa] //true
 
 It also works providing the ```Class``` with ```classOf[Kid]``` instead of the ```ClassTag```.
 
+
+Monad Transformers utilities
+----------------------
+
+Using Monad Transformers you can work with complex types easily. Currently, there are two types
+supported: ```Try[List[A]]``` and ```Try[Option[A]]```. Also, you can use ```Either[Throwable, List[A]]```
+and ```Either[Throwable, Option[A]]``` equivalently.
+
+The way to work with this functionality is using for comprehensions. With monad transformers we can iterate
+through two levels of types. For example, if we have a ```Try[List[A]]```, we can iterate the list keeping the
+type ```Try```. The same with the type ```Try[Option[A]]```.
+
+Method to uses Monad Transformers with list is called ```get values```. On the other hand, using ```get value```
+you could use it with an ```Option``` type.
+
+I.e.:
+
+```scala
+
+  import com.stratio.common.utils.functional.MonadTransformerDSL._
+  import TryFunctorConversionUtils._
+
+  (for {
+    x <- get values Try(List("a", "b"))
+  } yield (x, x)).run  //Try(List(("a", "a"), ("b", "b")))
+
+  (for {
+    x <- get value Try(Option("a"))
+  } yield (x, x)).run  //Try(Option(("a", "a")))
+
+```
+
+Have in mind that to undone the monad transformer and keep working with the original types, it is necessary a call to the
+```run``` method.
+
+To complement the monad transformers with ```Option``` types, it's also provided some extra functionality:
+
+- ```orThrow```: throw an exception if the ```Option``` is ```None```.
+
+```scala
+
+  (for {
+    x <- get value Try(Option("a")) orThrow new Exception("Exception message")
+  } yield (x, x)).run  //Try(Option(("a", "a")))
+
+  (for {
+    x <- get value Try(None) orThrow new Exception("Exception message")
+  } yield (x, x)).run  //An exception is thrown
+
+```
+
+- ```flatten```: it realizes a flatten. The ```Optio```n is removed but keeping the ```Try```.
+An exception is thrown if the ```Option``` is ```None```.
+
+```scala
+
+  (for {
+    x <- get value Try(Option("a"))
+  } yield (x, x)).run.flatten  //Try(("a", "a"))
+
+  (for {
+    x <- get value Try(None)
+  } yield (x, x)).run.flatten  //An exception is thrown
+
+```
+
+- ```flattenOr```: same functionality as flatten but providing an alternative if the ```Option``` is ```None```.
+
+```scala
+
+  (for {
+    x <- get value Try(Option("a"))
+  } yield (x, x)).run.flattenOr(("b", "b"))  //Try(("a", "a"))
+
+  (for {
+    x <- get value Try(None)
+  } yield (x, x)).run.flattenOr(("b", "b"))  //Try(("b", "b"))
+
+```
+
 Concurrent utilities
 ====================
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <curator.version>2.9.0</curator.version>
         <spark.version>1.5.2</spark.version>
         <slf4j.version>1.7.7</slf4j.version>
+        <scalaz-version>7.2.1</scalaz-version>
         <!-- Scala version and cross build properties -->
         <scala.binary.version>2.10</scala.binary.version>
         <scala.version>2.10.4</scala.version>
@@ -115,6 +116,12 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.scalaz</groupId>
+            <artifactId>scalaz-core_${scala.binary.version}</artifactId>
+            <version>${scalaz-version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/scala/com/stratio/common/utils/functional/MonadTransformerDSL.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/MonadTransformerDSL.scala
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils.functional
+
+import scala.util.Try
+
+import scalaz._
+import Scalaz._
+import scalaz.ListT._
+import scalaz.OptionT._
+
+object MonadTransformerDSL {
+
+  //Type definitions
+  type TryFunctor[A] = Either[Throwable, A]
+  type ListTryFunctorT[A] = ListT[TryFunctor, A]
+  type OptionTryFunctorT[A] = OptionT[TryFunctor, A]
+
+  /** Conversions between Try and TryFunctor (Either[Throwable, A]) */
+  object TryFunctorConversionUtils {
+    
+    implicit def fromTryToTryFunctor[A](t: Try[A]): TryFunctor[A] = t match {
+      case scala.util.Success(x) => Right(x)
+      case scala.util.Failure(ex: Throwable) => Left(ex)
+    }
+
+    implicit def fromTryFunctorToTry[A](t: TryFunctor[A]): Try[A] = t match {
+      case Left(ex: Throwable) => Try(throw ex)
+      case Right(value) => Try(value)
+    }
+  }
+
+  /** Utils to OptionT[TryFunctor[Option, A]] */
+  implicit class RichOptionTryFunctorT[A](o: OptionTryFunctorT[A]) {
+    def orThrow(ex: => Exception): OptionTryFunctorT[A] =
+      optionT(o.run map (_ orElse (throw ex)))
+  }
+
+  /** Utils to TryFunctor[Option, A] */
+  implicit class RichTryFunctorOption[A](t: TryFunctor[Option[A]]) {
+
+    def flatten: TryFunctor[A] =
+      flattenOr(new RuntimeException("Error trying to flatten a TryFunctor with None"))
+
+    def flattenOr(ex: => Exception)(implicit d1: DummyImplicit): TryFunctor[A] =
+      t map (_ getOrElse (throw ex))
+
+    def flattenOr[B >: A](alternative: => B): TryFunctor[B] =
+      t map (_ getOrElse alternative )
+
+  }
+
+  //scalastyle:off
+  object get {
+
+    // ListT Functions
+
+    def values[A](v : A): ListTryFunctorT[A] = values(Try(List(v)))
+
+    def values[A](v : List[A]): ListTryFunctorT[A] = values(Try(v))
+
+    def values[A](v : Try[List[A]]): ListT[TryFunctor, A] =
+      values(TryFunctorConversionUtils.fromTryToTryFunctor(v))
+
+    def values[A](v : TryFunctor[List[A]]): ListT[TryFunctor, A] = listT(v)
+
+    // OptionT Functions
+
+    def value[A](v : A): OptionTryFunctorT[A] = value(Try(Option(v)))
+
+    def value[A](v : Option[A]): OptionTryFunctorT[A] = value(Try(v))
+
+    def value[A](v : Try[Option[A]]): OptionT[TryFunctor, A] =
+      value(TryFunctorConversionUtils.fromTryToTryFunctor(v))
+
+    def value[A](v : TryFunctor[Option[A]]): OptionT[TryFunctor, A] = optionT(v)
+  }
+
+}

--- a/src/test/scala/com/stratio/common/utils/functional/MonadTransformerDSLTest.scala
+++ b/src/test/scala/com/stratio/common/utils/functional/MonadTransformerDSLTest.scala
@@ -1,0 +1,265 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.common.utils.functional
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest._
+import scala.util.{ Try, Failure => TryFailure }
+import scalaz._
+import Scalaz._
+
+@RunWith(classOf[JUnitRunner])
+class MonadTransformerDSLTest extends WordSpec
+with Matchers {
+
+  import MonadTransformerDSL._
+  import TryFunctorConversionUtils._
+
+  val exception = new Exception("Error")
+
+  "Monad Tranformer DSL" when {
+
+    "works with Try of List" should {
+
+      "extract the values of the list" in {
+
+        val tryListAB = Try(List("a", "b"))
+        val tryListA = Try(List("a"))
+        val tryListB = Try(List("b"))
+        val tryEmptyList = Try(List.empty[String])
+        val tryFailure: Try[List[String]] = Try(throw exception)
+
+        val result1: Try[List[(String, String)]] =
+          (
+            for {
+              x <- get values tryListAB
+            } yield (x, x)
+          ).run
+
+        result1 should be(Try(List(("a", "a"), ("b", "b"))))
+
+        val result2: Try[List[(String, String)]] =
+          (
+            for {
+              x <- get values tryListA
+              y <- get values tryListB
+            } yield (x, y)
+          ).run
+
+        result2 should be(Try(List(("a", "b"))))
+
+        val result3: Try[List[(String, String)]] =
+          (
+            for {
+              x <- get values tryListA
+              y <- get values List("b")
+            } yield (x, y)
+          ).run
+
+        result3 should be(Try(List(("a", "b"))))
+
+        val result4: Try[List[(String, String)]] =
+          (
+            for {
+              x <- get values tryListA
+              y <- get values "b"
+            } yield (x, y)
+          ).run
+
+        result4 should be(Try(List(("a", "b"))))
+
+        val result5: Try[List[(String, String)]] =
+          (
+            for {
+              x <- get values tryEmptyList
+            } yield (x, x)
+          ).run
+
+        result5 should be(Try(List.empty[String]))
+
+        val result6: Try[List[(String, String)]] =
+          (
+            for {
+              x <- get values tryFailure
+            } yield (x, x)
+          ).run
+
+        result6 should be(TryFailure(exception))
+      }
+    }
+
+    "works with Try of Option" should {
+
+      "extract the values of the option" in {
+
+        val tryOptionA = Try(Option("a"))
+        val tryOptionB = Try(Option("b"))
+        val tryEmptyOption = Try(Option.empty[String])
+        val tryFailure: Try[Option[String]] = Try(throw exception)
+
+        val result1: Try[Option[(String, String)]] =
+          (
+            for {
+              x <- get value tryOptionA
+            } yield (x, x)
+          ).run
+
+        result1 should be(Try(Option(("a", "a"))))
+
+        val result2: Try[Option[(String, String)]] =
+          (
+            for {
+              x <- get value tryOptionA
+              y <- get value tryOptionB
+            } yield (x, y)
+          ).run
+
+        result2 should be(Try(Option(("a", "b"))))
+
+        val result3: Try[Option[(String, String)]] =
+          (
+            for {
+              x <- get value tryOptionA
+              y <- get value Option("b")
+            } yield (x, y)
+          ).run
+
+        result3 should be(Try(Option(("a", "b"))))
+
+        val result4: Try[Option[(String, String)]] =
+          (
+            for {
+              x <- get value tryOptionA
+              y <- get value "b"
+            } yield (x, y)
+          ).run
+
+        result4 should be(Try(Option(("a", "b"))))
+
+        val result5: Try[Option[(String, String)]] =
+          (
+            for {
+              x <- get value tryEmptyOption
+            } yield (x, x)
+          ).run
+
+        result5 should be(Try(None))
+
+        val result6: Try[Option[(String, String)]] =
+          (
+            for {
+              x <- get value tryFailure
+            } yield (x, x)
+          ).run
+
+        result6 should be(TryFailure(exception))
+      }
+
+      "throw a new exception if the Option is None" in {
+
+        val tryOptionA = Try(Option("a"))
+        val tryEmptyOption = Try(Option.empty[String])
+
+        val result: Try[Option[(String, String)]] =
+          (for {
+            x <- get value tryOptionA orThrow exception
+          } yield (x, x)).run
+
+        result should be(Try(Option(("a", "a"))))
+
+        intercept[Exception] {
+          (for {
+            x <- get value tryEmptyOption orThrow exception
+          } yield (x, x)).run
+        }
+
+      }
+
+      "remove the option with the flatten method" in {
+
+        val tryOptionA = Try(Option("a"))
+        val tryEmptyOption = Try(Option.empty[String])
+
+        val result: Try[(String, String)] =
+          (for {
+            x <- get value tryOptionA
+          } yield (x, x)).run.flatten
+
+        result should be(Try(("a", "a")))
+
+        intercept[RuntimeException] {
+          (for {
+            x <- get value tryEmptyOption
+          } yield (x, x)).run.flatten
+        }
+
+      }
+
+      "remove the option with an alternative with the flatten method" in {
+
+        val tryOptionA = Try(Option("a"))
+        val tryEmptyOption = Try(Option.empty[String])
+
+        val result1: Try[(String, String)] =
+          (for {
+            x <- get value tryOptionA
+          } yield (x, x)).run.flattenOr(new Exception("Error"))
+
+        result1 should be(Try(("a", "a")))
+
+        intercept[Exception] {
+          (for {
+            x <- get value tryEmptyOption
+          } yield (x, x)).run.flattenOr(new Exception("Error"))
+        }
+
+        val result2: Try[(String, String)] =
+          (for {
+            x <- get value tryOptionA
+          } yield (x, x)).run.flattenOr(("b", "b"))
+
+        result2 should be(Try(("a", "a")))
+
+        val result3: Try[(String, String)] =
+          (for {
+            x <- get value tryEmptyOption
+          } yield (x, x)).run.flattenOr(("b", "b"))
+
+        result3 should be(Try(("b", "b")))
+
+      }
+    }
+
+    "uses implicits conversions" should {
+
+      "transform from Try to TryFunctor" in {
+
+        fromTryToTryFunctor(Try(Option("a"))) should be(Right(Option("a")))
+        fromTryToTryFunctor(Try(throw exception)) should be(Left(exception))
+
+      }
+
+      "transform from TryFunctor to Try" in {
+
+        fromTryFunctorToTry(Right(Option("a"))) should be(Try(Option("a")))
+        fromTryFunctorToTry(Left(exception)) should be(Try(throw exception))
+        
+      }
+    }
+  }
+}


### PR DESCRIPTION
Monad Transformers utilities
----------------------

Using Monad Transformers you can work with complex types easily. Currently, there are two types
supported: ```Try[List[A]]``` and ```Try[Option[A]]```. Also, you can use ```Either[Throwable, List[A]]```
and ```Either[Throwable, Option[A]]``` equivalently.

The way to work with this functionality is using for comprehensions. With monad transformers we can iterate
through two levels of types. For example, if we have a ```Try[List[A]]```, we can iterate the list keeping the
type ```Try```. The same with the type ```Try[Option[A]]```.

Method to uses Monad Transformers with list is called ```get values```. On the other hand, using ```get value```
you could use it with an ```Option``` type.

I.e.:

```scala

  import com.stratio.common.utils.functional.MonadTransformerDSL._
  import TryFunctorConversionUtils._

  (for {
    x <- get values Try(List("a", "b"))
  } yield (x, x)).run  //Try(List(("a", "a"), ("b", "b")))

  (for {
    x <- get value Try(Option("a"))
  } yield (x, x)).run  //Try(Option(("a", "a")))

```

Have in mind that to undone the monad transformer and keep working with the original types, it is necessary a call to the
```run``` method.

To complement the monad transformers with ```Option``` types, it's also provided some extra functionality:

- ```orThrow```: throw an exception if the ```Option``` is ```None```.

```scala

  (for {
    x <- get value Try(Option("a")) orThrow new Exception("Exception message")
  } yield (x, x)).run  //Try(Option(("a", "a")))

  (for {
    x <- get value Try(None) orThrow new Exception("Exception message")
  } yield (x, x)).run  //An exception is thrown

```

- ```flatten```: it realizes a flatten. The ```Optio```n is removed but keeping the ```Try```.
An exception is thrown if the ```Option``` is ```None```.

```scala

  (for {
    x <- get value Try(Option("a"))
  } yield (x, x)).run.flatten  //Try(("a", "a"))

  (for {
    x <- get value Try(None)
  } yield (x, x)).run.flatten  //An exception is thrown

```

- ```flattenOr```: same functionality as flatten but providing an alternative if the ```Option``` is ```None```.

```scala

  (for {
    x <- get value Try(Option("a"))
  } yield (x, x)).run.flattenOr(("b", "b"))  //Try(("a", "a"))

  (for {
    x <- get value Try(None)
  } yield (x, x)).run.flattenOr(("b", "b"))  //Try(("b", "b"))

```

@JSantosP @pfcoperez , feel free to review it!