### PR TITLE
Added logFunction macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,5 +295,34 @@ To set a monitor and subscribe it to our silly actor heartbeats you can just do 
   
 `testActor` will receive `HeartbeatLost(fallenId)` when the by-that-id identified service has stopped its heartbeat.
 
+Macros
+====================
+
+@LogFunction
+------------------------------------------------
+This macro annotation provides a mechanism to log a method call. It changes the method definition in order to
+send a trace log message with the name of the method and the value of its arguments. It's necessary to have a logger 
+value defined in the scope of the method.
+
+An example here:
+
+```scala
+
+trait Example extends LazyLogging {
+  @LogFunction
+  def foo(a: String, b: Int): String = a + b.toString
+}
+```
+
+The method definition, after the macro execution (in compile time) will be:
+
+```scala
+def foo(a: String, b: Int): String = {
+  logger.trace(s"Calling foo method with arguments a: $a, b: $b")
+  a + b.toString
+}
+```
+
+This work is in progress. Now, it's not working with method without arguments.
 
   

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <typesafe.version>1.3.0</typesafe.version>
         <scalatest.version>2.2.2</scalatest.version>
+        <mockito.version>1.10.19</mockito.version>
         <junit.version>4.11</junit.version>
         <akka.version>2.4.9</akka.version>
         <json4s.version>3.4.0</json4s.version>
@@ -87,6 +88,21 @@
             <version>${scala.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_${scala.binary.version}</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.21</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
             <version>${spark.version}</version>
@@ -102,6 +118,12 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
             <version>${scalatest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -177,6 +199,29 @@
                     <defaultScalaBinaryVersion>${default.scala.binary.version}</defaultScalaBinaryVersion>
                     <defaultScalaVersion>${default.scala.version}</defaultScalaVersion>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerPlugins>
+                                <compilerPlugin>
+                                    <groupId>org.scalamacros</groupId>
+                                    <artifactId>
+                                        paradise_${scala.version}
+                                    </artifactId>
+                                    <version>2.1.0</version>
+                                </compilerPlugin>
+                            </compilerPlugins>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/scala/com/stratio/common/utils/macros/LogFunction.scala
+++ b/src/main/scala/com/stratio/common/utils/macros/LogFunction.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils.macros
+
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+class LogFunction extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro LogFunctionImpl.impl
+}
+
+object LogFunctionImpl {
+
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    import c.universe._
+
+    def logMessage(methodName: TermName): String =
+      s"Calling method '$methodName' with arguments: "
+
+    def argumentsMap(args: List[List[ValDef]]): List[(String, TermName)] =
+      args.flatten.map { case arg =>
+        (arg.name.toString, arg.name)
+      }
+
+    def argumentsToString(args: List[List[ValDef]]): Tree =
+      q"""
+        ${argumentsMap(args)}.map { case (key, value) =>
+          key + " = " + value
+        }
+        .mkString(", ")
+      """
+
+    def modifiedFunction(funcDecl: DefDef): c.Expr[Any] = funcDecl match {
+      case q"$mods def $methodName[..$tpes](...$args): $returnType = { ..$body }" =>
+        c.Expr[Any](
+          q"""
+            $mods def $methodName[..$tpes](...$args): $returnType = {
+              logger.trace(${logMessage(methodName)} + ${argumentsToString(args)})
+              ..$body
+            }
+          """
+        )
+      case _ => c.abort(c.enclosingPosition, s" Match error with $funcDecl")
+    }
+
+    annottees.map(_.tree).toList match {
+      case (funcDecl: DefDef) :: Nil => modifiedFunction(funcDecl)
+      case _ => c.abort(c.enclosingPosition, "Invalid annottee. Only can be used with methods")
+    }
+
+  }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -14,10 +14,8 @@
 # limitations under the License.
 #
 
-common.root.logger=INFO
-
-log4j.logger.org.apache.zookeeper=OFF
-log4j.logger.org.apache.curator=OFF
-
-# Define the root logger to the system property "common.root.logger".
-log4j.rootLogger=${common.root.logger}
+log4j.rootCategory=DEBUG, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - %m%n
+log4j.logger.org.apache.directory=DEBUG

--- a/src/test/scala/com/stratio/common/utils/macros/LogFunctionSpec.scala
+++ b/src/test/scala/com/stratio/common/utils/macros/LogFunctionSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils.macros
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest._
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito.verify
+import org.slf4j.Logger
+
+@RunWith(classOf[JUnitRunner])
+class LogFunctionSpec extends WordSpec with Matchers with MockitoSugar {
+
+  trait MockLogger {
+
+    val logger = mock[Logger]
+  }
+
+  "A LogFunction Macro" when {
+    "a method with arguments is called" should {
+      "send a trace log message with info about the call" in new MockLogger {
+
+        @LogFunction
+        def example(a: String, b: Int): String = a + b.toString
+
+        example("hello", 1)
+        verify(logger).trace("Calling method 'example' with arguments: a = hello, b = 1")
+      }
+    }
+
+    "a method with several argument sets is called" should {
+      "send a trace log message with info about the call" in new MockLogger {
+
+        @LogFunction
+        def example(a: String)(b: Int): String = a + b.toString
+
+        example("hello")(1)
+        verify(logger).trace("Calling method 'example' with arguments: a = hello, b = 1")
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
@LogFunction
------------------------------------------------
This macro annotation provides a mechanism to log a method call. It changes the method definition in order to
send a trace log message with the name of the method and the value of its arguments. It's necessary to have a logger 
value defined in the scope of the method.

An example here:

```scala

trait Example extends LazyLogging {
  @LogFunction
  def foo(a: String, b: Int): String = a + b.toString
}
```

The method definition, after the macro execution (in compile time) will be:

```scala
def foo(a: String, b: Int): String = {
  logger.trace(s"Calling foo method with arguments a: $a, b: $b")
  a + b.toString
}
```

This work is in progress. Now, it's not working with method without arguments.