### PR TITLE
[DCS-231] DAO interface should not hide underlying exceptions

### DIFF
--- a/src/main/scala/com/stratio/common/utils/components/dao/DAOComponent.scala
+++ b/src/main/scala/com/stratio/common/utils/components/dao/DAOComponent.scala
@@ -29,7 +29,7 @@ trait DAOComponent[K, V, M] {
     def get(id: K) (implicit manifest: Manifest[M]): Try[Option[M]] =
       repository.get(entity, id).map(_.map(entity => fromVtoM(entity)))
 
-    def getAll() (implicit manifest: Manifest[M]): Try[List[M]] =
+    def getAll() (implicit manifest: Manifest[M]): Try[Seq[M]] =
       repository.getAll(entity).map(_.map(fromVtoM))
 
     def count(): Try[Long] =

--- a/src/main/scala/com/stratio/common/utils/components/dao/DAOComponent.scala
+++ b/src/main/scala/com/stratio/common/utils/components/dao/DAOComponent.scala
@@ -17,6 +17,8 @@ package com.stratio.common.utils.components.dao
 
 import com.stratio.common.utils.components.repository.RepositoryComponent
 
+import scala.util.Try
+
 trait DAOComponent[K, V, M] {
   self: RepositoryComponent[K, V] =>
 
@@ -24,31 +26,31 @@ trait DAOComponent[K, V, M] {
 
   trait DAO {
 
-    def get(id: K) (implicit manifest: Manifest[M]): Option[M] =
-      repository.get(entity, id).map(entity => fromVtoM(entity))
+    def get(id: K) (implicit manifest: Manifest[M]): Try[Option[M]] =
+      repository.get(entity, id).map(_.map(entity => fromVtoM(entity)))
 
-    def getAll() (implicit manifest: Manifest[M]): List[M] =
-      repository.getAll(entity).map(fromVtoM(_))
+    def getAll() (implicit manifest: Manifest[M]): Try[List[M]] =
+      repository.getAll(entity).map(_.map(fromVtoM))
 
-    def count(): Long =
+    def count(): Try[Long] =
       repository.count(entity)
 
-    def exists(id: K): Boolean =
+    def exists(id: K): Try[Boolean] =
       repository.exists(entity, id)
 
-    def create(id: K, element: M) (implicit manifest: Manifest[M]): M =
-      fromVtoM(repository.create(entity, id, fromMtoV(element)))
+    def create(id: K, element: M) (implicit manifest: Manifest[M]): Try[M] =
+      repository.create(entity, id, fromMtoV(element)).map(fromVtoM)
 
-    def update(id: K, element: M) (implicit manifest: Manifest[M]): Unit =
+    def update(id: K, element: M) (implicit manifest: Manifest[M]): Try[Unit] =
       repository.update(entity, id, fromMtoV(element))
 
-    def upsert(id: K, element: M) (implicit manifest: Manifest[M]): M =
-      fromVtoM(repository.upsert(entity, id, fromMtoV(element)))
+    def upsert(id: K, element: M) (implicit manifest: Manifest[M]): Try[M] =
+      repository.upsert(entity, id, fromMtoV(element)).map(fromVtoM)
 
-    def delete(id: K): Unit =
+    def delete(id: K): Try[Unit] =
       repository.delete(entity, id)
 
-    def deleteAll: Unit =
+    def deleteAll: Try[Unit] =
       repository.deleteAll(entity)
 
     def entity: String

--- a/src/main/scala/com/stratio/common/utils/components/repository/RepositoryComponent.scala
+++ b/src/main/scala/com/stratio/common/utils/components/repository/RepositoryComponent.scala
@@ -15,30 +15,32 @@
  */
 package com.stratio.common.utils.components.repository
 
+import scala.util.Try
+
 trait RepositoryComponent[K, V] {
 
   val repository: Repository
 
   trait Repository {
 
-    def get(entity: String, id: K): Option[V]
+    def get(entity: String, id: K): Try[Option[V]]
 
-    def getAll(entity: String): List[V]
+    def getAll(entity: String): Try[List[V]]
 
-    def getNodes(entity: String): List[K]
+    def getNodes(entity: String): Try[List[K]]
 
-    def count(entity: String): Long
+    def count(entity: String): Try[Long]
 
-    def exists(entity: String, id: K): Boolean
+    def exists(entity: String, id: K): Try[Boolean]
 
-    def create(entity: String, id: K, element: V): V
+    def create(entity: String, id: K, element: V): Try[V]
 
-    def upsert(entity: String, id: K, element: V): V
+    def upsert(entity: String, id: K, element: V): Try[V]
 
-    def update(entity: String, id: K, element: V): Unit
+    def update(entity: String, id: K, element: V): Try[Unit]
 
-    def delete(entity: String, id: K): Unit
+    def delete(entity: String, id: K): Try[Unit]
 
-    def deleteAll(entity: String): Unit
+    def deleteAll(entity: String): Try[Unit]
   }
 }

--- a/src/main/scala/com/stratio/common/utils/components/repository/RepositoryComponent.scala
+++ b/src/main/scala/com/stratio/common/utils/components/repository/RepositoryComponent.scala
@@ -25,9 +25,9 @@ trait RepositoryComponent[K, V] {
 
     def get(entity: String, id: K): Try[Option[V]]
 
-    def getAll(entity: String): Try[List[V]]
+    def getAll(entity: String): Try[Seq[V]]
 
-    def getNodes(entity: String): Try[List[K]]
+    def getNodes(entity: String): Try[Seq[K]]
 
     def count(entity: String): Try[Long]
 

--- a/src/main/scala/com/stratio/common/utils/functional/TryUtils.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/TryUtils.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils.functional
+
+import scala.util.{Failure, Success, Try}
+
+object TryUtils {
+
+  def sequence[T](s: Seq[Try[T]]): Try[Seq[T]] = {
+    def recSequence(s: Seq[Try[T]], acc: Seq[T]): Try[Seq[T]] =
+      s.headOption map {
+        case Failure(cause) => Failure(cause)
+        case Success(v) => recSequence(s.tail, v +: acc)
+      } getOrElse Success(acc reverse)
+    recSequence(s, Seq.empty)
+  }
+
+}

--- a/src/test/scala/com/stratio/common/utils/components/dao/DaoComponentTest.scala
+++ b/src/test/scala/com/stratio/common/utils/components/dao/DaoComponentTest.scala
@@ -19,6 +19,8 @@ import com.stratio.common.utils.components.repository.DummyRepositoryComponent
 import org.json4s.DefaultFormats
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.util.{Success, Try}
+
 class DaoComponentTest extends WordSpec with Matchers {
 
   trait DummyDAOComponentContext extends DummyDAOComponent {
@@ -40,11 +42,11 @@ class DaoComponentTest extends WordSpec with Matchers {
     "check if a value exists" should {
 
       "return true if the value exists" in new DummyDAOComponentContext {
-        dao.exists("key1") should be(true)
+        dao.exists("key1") should matchPattern {case Success(true) => }
       }
 
       "return false if the value doesn't exist" in new DummyDAOComponentContext {
-        dao.exists("keyNotFound") should be(false)
+        dao.exists("keyNotFound") should matchPattern {case Success(false) => }
       }
     }
 
@@ -72,7 +74,7 @@ class DaoComponentTest extends WordSpec with Matchers {
 
       "return false if the operation is not successful" in new DummyDAOComponentContext {
         dao.delete("keyNotFound")
-        dao.getAll().size should be(3)
+        dao.getAll().map(_.size) should matchPattern {case Success(3) => }
       }
     }
 
@@ -86,7 +88,7 @@ class DaoComponentTest extends WordSpec with Matchers {
 
       "return false if the operation is not successful" in new DummyDAOComponentContext {
         dao.update("keyNotFound", DummyModel("newValue"))
-        dao.getAll().size should be(3)
+        dao.getAll().map(_.size) should matchPattern {case Success(3) => }
       }
     }
 
@@ -104,7 +106,7 @@ class DaoComponentTest extends WordSpec with Matchers {
 
       "return false if the operation is not successful" in new DummyDAOComponentContext {
         dao.update("keyNotFound", DummyModel("newValue"))
-        dao.getAll().size should be(3)
+        dao.getAll().map(_.size) should matchPattern {case Success(3) => }
       }
     }
 

--- a/src/test/scala/com/stratio/common/utils/components/repository/DummyRepositoryComponent.scala
+++ b/src/test/scala/com/stratio/common/utils/components/repository/DummyRepositoryComponent.scala
@@ -36,28 +36,18 @@ trait DummyRepositoryComponent extends RepositoryComponent[String, String] {
     def get(entity: String, id: String): Try[Option[String]] =
       Try(memoryMap.get(entity).flatMap(_.get(id)))
 
-    def getAll(entity: String): Try[List[String]] =
-      Try(memoryMap.get(entity) match {
-        case Some(map: mutable.Map[String, String]) => map.values.toList.sortBy(identity)
-        case _ => List.empty
-      })
+    def getAll(entity: String): Try[Seq[String]] =
+      Try(memoryMap.get(entity).map(_.values.toList.sortBy(identity)).getOrElse(Seq.empty))
 
-    def getNodes(entity: String): Try[List[String]] =
-      Try(memoryMap.get(entity) match {
-        case Some(map: mutable.Map[String, String]) => map.keys.toList.sortBy(identity)
-        case _ => List.empty
-      })
+    def getNodes(entity: String): Try[Seq[String]] =
+      Try(memoryMap.get(entity).map(_.keys.toList.sortBy(identity)).getOrElse(Seq.empty))
 
     def count(entity: String): Try[Long] =
-      Try(memoryMap.get(entity) match {
-        case Some(value) => value.size
-        case None => 0
-      })
+      Try(memoryMap.get(entity).map(_.size).getOrElse(0).toLong)
 
-    def exists(entity:String, id: String): Try[Boolean] =
-      Try(memoryMap.get(entity) match {
-        case Some(value) => value.get(id).isDefined
-        case None => false
+    def exists(entity: String, id: String): Try[Boolean] =
+      Try(memoryMap.exists { case (key, entityMap) =>
+        key == entity && entityMap.keys.toList.contains(id)
       })
 
     def create(entity:String, id: String, element: String): Try[String] = {

--- a/src/test/scala/com/stratio/common/utils/components/repository/DummyRepositoryComponent.scala
+++ b/src/test/scala/com/stratio/common/utils/components/repository/DummyRepositoryComponent.scala
@@ -16,6 +16,7 @@
 package com.stratio.common.utils.components.repository
 
 import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
 
 trait DummyRepositoryComponent extends RepositoryComponent[String, String] {
 
@@ -32,55 +33,59 @@ trait DummyRepositoryComponent extends RepositoryComponent[String, String] {
 
   class DummyRepository() extends Repository {
 
-    def get(entity:String, id: String): Option[String] =
-      memoryMap.get(entity).flatMap(_.get(id))
+    def get(entity: String, id: String): Try[Option[String]] =
+      Try(memoryMap.get(entity).flatMap(_.get(id)))
 
-    def getAll(entity:String): List[String] =
-      memoryMap.get(entity) match {
-        case Some(map: mutable.Map[String,String]) => {
-          map.values.toList.sortBy(x => x)
-        }
-        case _ => List.empty[String]
-      }
+    def getAll(entity: String): Try[List[String]] =
+      Try(memoryMap.get(entity) match {
+        case Some(map: mutable.Map[String, String]) => map.values.toList.sortBy(identity)
+        case _ => List.empty
+      })
 
-    def getNodes(entity:String): List[String] =
-      memoryMap.get(entity) match {
-        case Some(map: mutable.Map[String,String]) => {
-          map.keys.toList.sortBy(x => x)
-        }
-        case _ => List.empty[String]
-      }
+    def getNodes(entity: String): Try[List[String]] =
+      Try(memoryMap.get(entity) match {
+        case Some(map: mutable.Map[String, String]) => map.keys.toList.sortBy(identity)
+        case _ => List.empty
+      })
 
-    def count(entity: String): Long =
-      memoryMap.get(entity) match {
+    def count(entity: String): Try[Long] =
+      Try(memoryMap.get(entity) match {
         case Some(value) => value.size
         case None => 0
-      }
+      })
 
-    def exists(entity:String, id: String): Boolean =
-      memoryMap.get(entity) match {
+    def exists(entity:String, id: String): Try[Boolean] =
+      Try(memoryMap.get(entity) match {
         case Some(value) => value.get(id).isDefined
         case None => false
-      }
+      })
 
-    def create(entity:String, id: String, element: String): String = {
-      if (!exists(entity, id)) {
-        memoryMap.put(entity, mutable.Map(id -> element))
+    def create(entity:String, id: String, element: String): Try[String] = {
+      exists(entity, id).foreach {
+        case false => memoryMap.put(entity, mutable.Map(id -> element))
+        case true => ()
       }
-      element
+      Success(element)
     }
 
-    override def upsert(entity: String, id: String, element: String): String = {
+    override def upsert(entity: String, id: String, element: String): Try[String] = {
       memoryMap.put(entity, mutable.Map(id -> element))
-      element
+      Success(element)
     }
 
-    def update(entity:String, id: String, element: String): Unit =
-      if (exists(entity, id)) memoryMap.put(entity, mutable.Map(id -> element))
+    def update(entity: String, id: String, element: String): Try[Unit] =
+      exists(entity, id).map {
+        case false => ()
+        case true => memoryMap.put(entity, mutable.Map(id -> element))
+      }
 
-    def delete(entity:String, id: String): Unit =
-      if (exists(entity, id)) memoryMap.get(entity).get.remove(id)
+    def delete(entity:String, id: String): Try[Unit] = {
+      exists(entity, id).map{
+        case false => ()
+        case true => memoryMap(entity).remove(id)
+      }
+    }
 
-    def deleteAll(entity:String): Unit = memoryMap.remove(entity)
+    def deleteAll(entity:String): Try[Unit] = Try(memoryMap.remove(entity))
   }
 }

--- a/src/test/scala/com/stratio/common/utils/components/repository/RepositoryComponentTest.scala
+++ b/src/test/scala/com/stratio/common/utils/components/repository/RepositoryComponentTest.scala
@@ -19,9 +19,11 @@ import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner
 
+import scala.util.Success
+
 @RunWith(classOf[JUnitRunner])
 class RepositoryComponentTest extends WordSpec
-  with Matchers {
+  with Matchers with Inside{
 
   trait DummyRepositoryContext extends DummyRepositoryComponent
 
@@ -33,98 +35,102 @@ class RepositoryComponentTest extends WordSpec
     "get an element" should {
 
       "return an option with the value if the key exists" in new DummyRepositoryContext {
-        repository.get(Entity, "key1") should be(Some("value1"))
+        repository.get(Entity, "key1") should be(Success(Some("value1")))
       }
 
       "return None if the key doesn't exist" in new DummyRepositoryContext {
-        repository.get(Entity, keyNotFound) should be(None)
+        repository.get(Entity, keyNotFound) should be(Success(None))
       }
     }
 
     "getAll elements" should {
       "return all elements if the operation is successful" in new DummyRepositoryContext {
-        repository.getAll(Entity) should be(List("value1", "value2", "value3"))
+        inside(repository.getAll(Entity)) { case Success(list) =>
+            list should have length 3
+            list should contain allOf ("value1", "value2", "value3")
+        }
+
       }
 
       "return and empty list if the operation is not successful" in new DummyRepositoryContext {
-        repository.getAll(keyNotFound) should be(List.empty[String])
+        repository.getAll(keyNotFound) should be(Success(List.empty[String]))
       }
     }
 
     "getNodes elements" should {
       "return all nodes if the operation is successful" in new DummyRepositoryContext {
-        repository.getNodes(Entity) should be(List("key1", "key2", "key3"))
+        repository.getNodes(Entity) should be(Success(List("key1", "key2", "key3")))
       }
 
       "return and empty list if the operation is not successful" in new DummyRepositoryContext {
-        repository.getNodes(keyNotFound) should be(List.empty[String])
+        repository.getNodes(keyNotFound) should be(Success(List.empty[String]))
       }
     }
 
     "check if a value exists" should {
 
       "return true if the value exists" in new DummyRepositoryContext {
-        repository.exists(Entity, "key1") should be(true)
+        repository.exists(Entity, "key1") should be (Success(true))
       }
 
       "return false if the value doesn't exist" in new DummyRepositoryContext {
-        repository.exists(Entity, keyNotFound) should be(false)
+        repository.exists(Entity, keyNotFound) should be (Success(false))
       }
     }
 
     "create a new value" should {
 
       "return true if the operation is successful" in new DummyRepositoryContext {
-        repository.get(Entity, keyNotFound) should be(None)
-        repository.create(Entity, keyNotFound, "newValue") should be("newValue")
-        repository.get(Entity, keyNotFound) should be(Some("newValue"))
+        repository.get(Entity, keyNotFound) should be(Success(None))
+        repository.create(Entity, keyNotFound, "newValue") should be(Success("newValue"))
+        repository.get(Entity, keyNotFound) should be(Success(Some("newValue")))
       }
 
       "return false if the operation is not successful" in new DummyRepositoryContext {
-        repository.create(Entity, "key1", "newValue") should be("newValue")
-        repository.count(Entity) should be(3)
+        repository.create(Entity, "key1", "newValue") should be(Success("newValue"))
+        repository.count(Entity) should be(Success(3))
       }
     }
 
     "remove a value" should {
 
       "check that the element does not exist when it has been removed" in new DummyRepositoryContext {
-        repository.get(Entity, "key1") should be(Some("value1"))
+        repository.get(Entity, "key1") should be(Success(Some("value1")))
         repository.delete(Entity, "key1")
-        repository.get(Entity, "key1") should be(None)
+        repository.get(Entity, "key1") should be(Success(None))
       }
 
       "do anything when a not existing element is removed" in new DummyRepositoryContext {
         repository.delete(Entity, keyNotFound)
-        repository.count(Entity) should be(3)
+        repository.count(Entity) should be(Success(3))
       }
     }
 
     "remove all values" should {
 
       "check that the element does not exist when it has been removed all" in new DummyRepositoryContext {
-        repository.get(Entity, "key1") should be(Some("value1"))
+        repository.get(Entity, "key1") should be(Success(Some("value1")))
         repository.deleteAll(Entity)
-        repository.get(Entity, "key1") should be(None)
+        repository.get(Entity, "key1") should be(Success(None))
       }
 
       "do anything when a not existing element is removed all" in new DummyRepositoryContext {
         repository.deleteAll(Entity)
-        repository.count(Entity) should be(0)
+        repository.count(Entity) should be(Success(0))
       }
     }
 
     "update a value" should {
 
       "check that the element has been updated with the new value" in new DummyRepositoryContext {
-        repository.get(Entity, "key1") should be(Some("value1"))
+        repository.get(Entity, "key1") should be(Success(Some("value1")))
         repository.update(Entity, "key1", "newValue")
-        repository.get(Entity, "key1") should be(Some("newValue"))
+        repository.get(Entity, "key1") should be(Success(Some("newValue")))
       }
 
       "do anything when a not existing element is updated" in new DummyRepositoryContext {
         repository.update(Entity, keyNotFound, "newValue")
-        repository.count(Entity) should be(3)
+        repository.count(Entity) should be(Success(3))
       }
     }
   }

--- a/src/test/scala/com/stratio/common/utils/functional/TryUtilsTest.scala
+++ b/src/test/scala/com/stratio/common/utils/functional/TryUtilsTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.common.utils.functional
+
+import org.scalatest.{FlatSpec, Inside, Matchers}
+
+import scala.util.{Failure, Success}
+
+class TryUtilsTest extends FlatSpec with Matchers with Inside{
+
+  val exception = new Exception("Error")
+
+  behavior of "Try"
+
+  it should "allow transforming a Seq[Try[A]] containing a Failure into a Failure" in {
+
+    TryUtils.sequence(Seq(Success(1), Failure(exception))) shouldBe a[Failure[_]]
+
+  }
+
+  it should "allow transforming a Seq[Try[A]] without failures into a Success[Seq[A]]" in {
+
+    inside(TryUtils.sequence(Seq(Success(1), Success(2)))) {
+      case Success(seq) => seq should contain theSameElementsInOrderAs Seq(1,2)
+    }
+
+  }
+
+}

--- a/src/test/scala/com/stratio/common/utils/integration/ZookeeperTest.scala
+++ b/src/test/scala/com/stratio/common/utils/integration/ZookeeperTest.scala
@@ -24,6 +24,8 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
+import scala.util.Success
+
 @RunWith(classOf[JUnitRunner])
 class ZookeeperIntegrationTest extends WordSpec
   with Matchers
@@ -55,32 +57,32 @@ class ZookeeperIntegrationTest extends WordSpec
 
     "save a dummy in ZK and get it" in  new DummyDAOComponent {
       dao.create("test1", new Dummy("value"))
-      dao.get("test1") should be(Some(Dummy("value")))
+      dao.get("test1") should be(Success(Some(Dummy("value"))))
     }
 
     "update the dummy in ZK and get it" in  new DummyDAOComponent {
       dao.update("test1", new Dummy("newValue"))
-      dao.get("test1") should be(Some(Dummy("newValue")))
+      dao.get("test1") should be(Success(Some(Dummy("newValue"))))
     }
 
     "upser the dummy in ZK and get it" in  new DummyDAOComponent {
       dao.upsert("test1", new Dummy("newValue"))
-      dao.get("test1") should be(Some(Dummy("newValue")))
+      dao.get("test1") should be(Success(Some(Dummy("newValue"))))
       dao.upsert("test1", new Dummy("newValue2"))
-      dao.get("test1") should be(Some(Dummy("newValue2")))
+      dao.get("test1") should be(Success(Some(Dummy("newValue2"))))
     }
 
     "delete the dummy in ZK and get it with a None result" in  new DummyDAOComponent {
       dao.delete("test1")
-      dao.exists("test1") should be(false)
+      dao.exists("test1") should be (Success(false))
     }
 
     "save a dummy in ZK and delete all" in  new DummyDAOComponent {
       dao.create("test1", new Dummy("value"))
-      dao.get("test1") should be(Some(Dummy("value")))
+      dao.get("test1") should be(Success(Some(Dummy("value"))))
       dao.deleteAll
-      dao.exists("test1") should be(false)
-      dao.count() should be(0)
+      dao.exists("test1") should be (Success(false))
+      dao.count() should be(Success(0))
     }
   }
 }

--- a/src/test/scala/com/stratio/common/utils/integration/ZookeeperTest.scala
+++ b/src/test/scala/com/stratio/common/utils/integration/ZookeeperTest.scala
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 @RunWith(classOf[JUnitRunner])
 class ZookeeperIntegrationTest extends WordSpec
@@ -82,7 +82,7 @@ class ZookeeperIntegrationTest extends WordSpec
       dao.get("test1") should be(Success(Some(Dummy("value"))))
       dao.deleteAll
       dao.exists("test1") should be (Success(false))
-      dao.count() should be(Success(0))
+      dao.count() shouldBe a[Failure[_]]
     }
   }
 }


### PR DESCRIPTION
Replace DAO operations like 'getAll[T]: List[T]' with the new interface 'getAll[T]: Try[List[T]]' 

The current implementation is also hiding the errors by doing Try(..).getOrElse(..empty); thus, the library's users cannot distinguish whether the result is empty or the connection has failed.