### PR TITLE
[CROSSDATA-1199] Make Try.sequence tail recursive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Only listing significant user-visible, not internal code cleanups and minor bug 
 
 ## 0.12.0 (upcoming)
 
-* Pending changelog
+* Make "Try.sequence" tail recursive 
 
 ## 0.11.0 (July 06, 2017)
 

--- a/src/main/scala/com/stratio/common/utils/functional/TryUtils.scala
+++ b/src/main/scala/com/stratio/common/utils/functional/TryUtils.scala
@@ -15,16 +15,23 @@
  */
 package com.stratio.common.utils.functional
 
+import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 
 object TryUtils {
 
   def sequence[T](s: Seq[Try[T]]): Try[Seq[T]] = {
+
+    @tailrec
     def recSequence(s: Seq[Try[T]], acc: Seq[T]): Try[Seq[T]] =
-      s.headOption map {
-        case Failure(cause) => Failure(cause)
-        case Success(v) => recSequence(s.tail, v +: acc)
-      } getOrElse Success(acc reverse)
+      if (s.nonEmpty) {
+        s.head match {
+          case Success(v) => recSequence(s.tail, v +: acc)
+          case Failure(cause) => Failure(cause)
+        }
+      } else {
+        Success(acc reverse)
+      }
     recSequence(s, Seq.empty)
   }
 

--- a/src/test/scala/com/stratio/common/utils/functional/TryUtilsTest.scala
+++ b/src/test/scala/com/stratio/common/utils/functional/TryUtilsTest.scala
@@ -39,4 +39,12 @@ class TryUtilsTest extends FlatSpec with Matchers with Inside{
 
   }
 
+  it should "allow transforming a Seq[Try[A]] of 100000 values into a Success[Seq[A]]" in {
+
+    val seqSuccess = (1 to 100000) map (Success(_))
+    noException shouldBe thrownBy (TryUtils.sequence(seqSuccess))
+
+  }
+
+
 }


### PR DESCRIPTION
Fix the following issue: 

A SHOW TABLES with ZKCatalog and >10K talbes causes a StackOverflow error (default stack configuration) because of a non-tail recursive implementation of Try.sequence:
 ```
def sequence[T](s: Seq[Try[T]]): Try[Seq[T]] = {
    def recSequence(s: Seq[Try[T]], acc: Seq[T]): Try[Seq[T]] =
      s.headOption map {
        case Failure(cause) => Failure(cause)
        case Success(v) => recSequence(s.tail, v +: acc)
      } getOrElse Success(acc reverse)
    recSequence(s, Seq.empty)
  }
```